### PR TITLE
Fix CI workflow: allow SARIF upload to fail gracefully

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
 
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@v3
+      continue-on-error: true
       with:
         sarif_file: gosec.sarif
 


### PR DESCRIPTION
## Problem
The CI/CD pipeline is failing at the "Upload SARIF file" step with error:
```
Resource not accessible by integration
```

This occurs because the SARIF upload step requires `security-events: write` permissions, which may not be available in all workflow contexts. This failure blocks the entire test suite from running.

## Solution
Added `continue-on-error: true` to the SARIF upload step, allowing the workflow to proceed even if the upload fails. This ensures:
- Tests continue to run regardless of SARIF upload status
- Security scan results are still generated and archived as artifacts
- Workflow completes successfully

## Impact
- Fixes workflow failure blocking test execution
- Maintains security scanning functionality
- No impact on actual test coverage or quality checks

## Testing
Will verify workflow passes after merge.