### PR TITLE
Fix all three workflow failures (Security Scan + Docker builds)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./docker
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,12 +42,13 @@ jobs:
       run: go mod download
 
     - name: Run GoSec Security Scanner
-      uses: securecodewarrior/github-action-gosec@master
-      with:
-        args: '-fmt sarif -out gosec.sarif ./...'
+      run: |
+        go install github.com/securego/gosec/v2/cmd/gosec@latest
+        gosec -fmt sarif -out gosec.sarif ./...
 
     - name: Upload GoSec SARIF file
       uses: github/codeql-action/upload-sarif@v3
+      continue-on-error: true
       with:
         sarif_file: gosec.sarif
 
@@ -89,7 +90,7 @@ jobs:
     - name: Build Docker image for scanning
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./docker
         push: false
         tags: shopogoda:security-scan
         load: true


### PR DESCRIPTION
## Summary

Fixes all three workflow failures identified in commit fdfab79:

### 1. Security Vulnerability Scan ✅
- **Issue**: Invalid action `securecodewarrior/github-action-gosec` (repository not found)
- **Fix**: Replace with direct gosec installation via `go install`
- **Additional**: Added `continue-on-error: true` to SARIF upload for resilience

### 2. Docker Image Security Scan ✅  
- **Issue**: `ERROR: failed to read dockerfile: open Dockerfile: no such file or directory`
- **Root cause**: Docker context was `.` but Dockerfile is in `./docker/`
- **Fix**: Update context to `./docker`

### 3. Build & Push Docker Image ✅
- **Issue**: Same Dockerfile missing error
- **Root cause**: Same incorrect context path
- **Fix**: Update context from `.` to `./docker`

## Changes

**`.github/workflows/security.yml`**:
- Line 44-53: Replace gosec action with direct installation and execution
- Line 51: Add `continue-on-error: true` to SARIF upload
- Line 93: Update Docker build context to `./docker`

**`.github/workflows/ci.yml`**:
- Line 183: Update Docker build context to `./docker`

## Testing

All three workflows should now succeed:
- ✅ Security Vulnerability Scan will complete with gosec results
- ✅ Docker Image Security Scan will build image from correct location
- ✅ Build & Push Docker Image will build and push successfully

## Related

- Fixes errors from commit fdfab79cd0a54d2973a3bb7e7f52423952d802c9
- Follows up on PR #19 which fixed SARIF upload in CI pipeline