### PR TITLE
Fix Dockerfile COPY instruction syntax error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,8 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/shopogoda .
 
-# Copy configuration files if they exist
-COPY --from=builder /app/configs/ ./configs/ 2>/dev/null || mkdir -p ./configs/
+# Create configs directory (COPY can't use shell operators)
+RUN mkdir -p ./configs
 
 # Change ownership to non-root user
 RUN chown -R shopogoda:shopogoda /app


### PR DESCRIPTION
## Summary

Fixes Docker Image Security Scan failure after PR #21 merge.

## Error

```
ERROR: failed to calculate checksum: "/-p": not found
```

From Dockerfile line 35:
```dockerfile
COPY --from=builder /app/configs/ ./configs/ 2>/dev/null || mkdir -p ./configs/
```

## Root Cause

Docker's COPY instruction doesn't support:
- Shell redirection (`2>/dev/null`)
- Shell operators (`||`)
- Shell commands (`mkdir -p`)

BuildKit interprets these as part of the file path, causing checksum calculation to fail when it tries to find a path literally named `"/-p"`.

## Solution

Replace the problematic COPY with a simple RUN command:
```dockerfile
RUN mkdir -p ./configs
```

**Benefits:**
- ✅ Creates directory if needed
- ✅ No dependency on `/app/configs/` existing in builder stage
- ✅ Simpler and more reliable
- ✅ Proper shell command execution

## Testing

This will fix the Docker Image Security Scan workflow that's currently failing on main.