### PR TITLE
docs: Update CHANGELOG with handler test coverage progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### In Progress
-- Test coverage improvements (27.4% → 28.4%, target: 40%)
+- Test coverage improvements (27.4% → 29.1%, target: 40%)
 - Video walkthrough
 
 ### Added
@@ -77,6 +77,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 10 test cases covering valid timezones (UTC, America/New_York, Europe/Kyiv, etc.)
   - Invalid timezone detection (malformed, empty, partial timezone names)
   - Edge case handling (empty string defaults to Local timezone)
+- **Handler Helper Function Tests**: Added comprehensive unit tests for handler utility functions
+  - 5 test functions with 36 test cases covering helper utilities
+  - TestGetAQIDescription: Air quality index description mapping (14 cases: Good, Moderate, Unhealthy, Hazardous)
+  - TestGetHealthRecommendation: Health recommendations based on AQI (12 cases)
+  - TestGetLocalizedUnitsText: Unit system localization (4 cases: metric, imperial, fallback)
+  - TestGetLocalizedRoleName: User role localization (4 cases: Admin, Moderator, User, default)
+  - TestGetLocalizedStatusText: Active/inactive status localization (2 cases)
+  - Handler package coverage: 2.1% → 3.2% (+1.1%)
+  - Overall coverage: 28.6% → 29.1% (+0.5%)
 
 ### Fixed
 - **Demo Service ClearDemoData Bug**: Fixed SQL error when deleting demo user


### PR DESCRIPTION
Update CHANGELOG to reflect handler helper function test additions from PR #52.

## Changes
- Updated coverage progress: 27.4% → 29.1%
- Added Handler Helper Function Tests section with detailed breakdown
- Documented 5 new test functions with 36 test cases
- Handler package coverage: 2.1% → 3.2% (+1.1%)
- Overall coverage: 28.6% → 29.1% (+0.5%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)