### PR TITLE
fix: Correct workflow environment file paths and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
     - name: Set up environment
       run: |
         echo "Setting up production environment"
-        cp .env.production.example .env.production
+        cp .env.prod.example .env.production
         # In real deployment, secrets would be injected from GitHub Secrets
         echo "VERSION=latest" >> .env.production
         echo "GITHUB_REPOSITORY=${{ github.repository }}" >> .env.production

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,6 +19,8 @@ jobs:
   quality-analysis:
     name: Code Quality Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Allow commit comments
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
Fixes two GitHub Actions workflow failures identified after merging PR #66:

### 1. CI Workflow - Environment File Path
**File**: `.github/workflows/ci.yml:273`  
**Issue**: Workflow references `.env.production.example` but file is named `.env.prod.example`  
**Error**: `cp: cannot stat '.env.production.example': No such file or directory`  
**Fix**: Updated to use correct filename `.env.prod.example`

### 2. Code Quality Workflow - Missing Permissions  
**File**: `.github/workflows/code-quality.yml:22-23`  
**Issue**: Workflow lacks write permissions to create commit comments  
**Error**: `RequestError [HttpError]: Resource not accessible by integration`  
**Fix**: Added `permissions: contents: write` to job

## Testing
- ✅ File path verified in repository
- ✅ Permissions syntax validated
- ✅ Both changes follow GitHub Actions best practices

## Related Issues
Resolves workflow failures from:
- https://github.com/valpere/shopogoda/actions/runs/18342213789
- https://github.com/valpere/shopogoda/actions/runs/18342214065
- https://github.com/valpere/shopogoda/actions/runs/18342214087

🤖 Generated with [Claude Code](https://claude.com/claude-code)