### PR TITLE
fix(security): fix gosec suppressions and bump GO_VERSION to 1.25 in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: 1.24
+  GO_VERSION: '1.25'
 
 jobs:
   security-scan:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type DatabaseConfig struct {
 	Host     string `mapstructure:"host"`
 	Port     int    `mapstructure:"port"`
 	User     string `mapstructure:"user"`
-	Password string `mapstructure:"password"`
+	Password string `mapstructure:"password"` // #nosec G117
 	Name     string `mapstructure:"name"`
 	SSLMode  string `mapstructure:"ssl_mode"`
 }
@@ -39,7 +39,7 @@ type DatabaseConfig struct {
 type RedisConfig struct {
 	Host     string `mapstructure:"host"`
 	Port     int    `mapstructure:"port"`
-	Password string `mapstructure:"password"`
+	Password string `mapstructure:"password"` // #nosec G117
 	DB       int    `mapstructure:"db"`
 }
 

--- a/internal/handlers/commands/commands.go
+++ b/internal/handlers/commands/commands.go
@@ -4018,7 +4018,7 @@ func (h *CommandHandler) processExportRequest(bot *gotgbot.Bot, ctx *ext.Context
 		return fmt.Errorf("failed to create temporary file: %w", err)
 	}
 	defer func() {
-		if err := os.Remove(tempFile.Name()); err != nil {
+		if err := os.Remove(tempFile.Name()); err != nil { // #nosec G703
 			h.logger.Warn().Err(err).Str("file", tempFile.Name()).Msg("Failed to remove temporary file")
 		}
 	}()

--- a/internal/services/weather_service.go
+++ b/internal/services/weather_service.go
@@ -395,7 +395,7 @@ func (s *WeatherService) geocodeWithNominatim(ctx context.Context, locationName 
 	// Set User-Agent as required by Nominatim usage policy
 	req.Header.Set("User-Agent", s.getUserAgent())
 
-	resp, err := s.httpClient.Do(req) // nosec G704
+	resp, err := s.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return nil, fmt.Errorf("failed to make Nominatim request: %w", err)
 	}
@@ -470,7 +470,7 @@ func (s *WeatherService) reverseGeocodeWithNominatim(ctx context.Context, lat, l
 	// Set User-Agent as required by Nominatim usage policy
 	req.Header.Set("User-Agent", s.getUserAgent())
 
-	resp, err := s.httpClient.Do(req) // nosec G704
+	resp, err := s.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return "", fmt.Errorf("failed to make Nominatim reverse request: %w", err)
 	}

--- a/pkg/weather/client.go
+++ b/pkg/weather/client.go
@@ -90,7 +90,7 @@ func (c *Client) GetCurrentWeather(ctx context.Context, lat, lon float64) (*Weat
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req) // nosec G704
+	resp, err := c.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
@@ -150,7 +150,7 @@ func (c *Client) GetForecast(ctx context.Context, lat, lon float64, days int) (*
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req) // nosec G704
+	resp, err := c.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
@@ -229,7 +229,7 @@ func (c *Client) GetAirQuality(ctx context.Context, lat, lon float64) (*AirQuali
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req) // nosec G704
+	resp, err := c.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
@@ -304,7 +304,7 @@ func (c *GeocodingClient) GeocodeLocation(ctx context.Context, locationName stri
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req) // nosec G704
+	resp, err := c.httpClient.Do(req) // #nosec G704
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}

--- a/tests/helpers/test_config.go
+++ b/tests/helpers/test_config.go
@@ -10,7 +10,7 @@ import (
 func GetTestConfig() *config.Config {
 	return &config.Config{
 		Bot: config.BotConfig{
-			Token: "test_bot_token",
+			Token: "test_bot_token", // #nosec G101
 			Debug: true,
 		},
 		Database: config.DatabaseConfig{


### PR DESCRIPTION
## Summary
- Fix `// nosec` → `// #nosec` comment format in `pkg/weather/client.go` and `internal/services/weather_service.go` (G704 SSRF false positives on config-driven HTTP calls)
- Add `// #nosec G703` to `os.Remove(tempFile.Name())` in commands.go (standard temp file cleanup)
- Add `// #nosec G101` to test credential in `tests/helpers/test_config.go`
- Add `// #nosec G117` to `Password` struct fields in `internal/config/config.go`
- Bump `GO_VERSION: 1.24` → `'1.25'` in `security.yml` to match `go 1.25.0` in go.mod

## Root cause
gosec's suppression comment requires a `#` prefix (`// #nosec`). Without it (`// nosec`), the comment is ignored and the issue is still reported. This caused gosec to report 10 issues and exit with code 1, failing the Security Scan workflow.

## Test plan
- [ ] Security Scan workflow passes on main after merge
- [ ] `gosec` reports `Issues: 0, Nosec: 10` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)